### PR TITLE
Creating a Bucket shouldn't try to request its data.

### DIFF
--- a/kintoclient/__init__.py
+++ b/kintoclient/__init__.py
@@ -135,8 +135,8 @@ class Bucket(object):
     def _get_collection_uri(self, collection_id):
         return '%s/collections/%s' % (self.uri, collection_id)
 
-    def get_collection(self, name):
-        return Collection(name, bucket=self, session=self.session)
+    def get_collection(self, name, **kwargs):
+        return Collection(name, bucket=self, session=self.session, **kwargs)
 
     def list_collections(self):
         uri = "%s/%s" % (self.uri, 'collections')

--- a/kintoclient/tests/test_client.py
+++ b/kintoclient/tests/test_client.py
@@ -109,6 +109,16 @@ class BucketTest(TestCase):
             session=self.session)
 
     @mock.patch('kintoclient.Collection')
+    def test_get_collections_params_are_passed_though(self, collection_mock):
+        bucket = Bucket('testbucket', session=self.session)
+        bucket.get_collection('mycollection', loads=False)
+        collection_mock.assert_called_with(
+            'mycollection',
+            bucket=bucket,
+            session=self.session,
+            loads=False)
+
+    @mock.patch('kintoclient.Collection')
     def test_collections_can_be_created_from_buckets(self, collection_mock):
         bucket = Bucket('testbucket', session=self.session)
         bucket.create_collection('mycollection')


### PR DESCRIPTION
``Bucket.permissions`` and ``Bucket.data`` should be lazy and requested when ask only.

There are cases where the user can access the collection data but has no right to fetch the bucket.