### PR TITLE
Invalid platform error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
     - TOX_ENV=flake8
 before_install:
     - pip install kinto
+    - make install-dev
     - make runkinto &
 install:
     - pip install tox

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import codecs
 import os
+import sys
 from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -14,6 +15,14 @@ REQUIREMENTS = [
     'unidecode',
     'six'
 ]
+
+
+if sys.version_info < (2, 7, 9):
+    # For secure SSL connexion with Python 2.7 (InsecurePlatformWarning)
+    REQUIREMENTS.append('PyOpenSSL')
+    REQUIREMENTS.append('ndg-httpsclient')
+    REQUIREMENTS.append('pyasn1')
+
 
 setup(name='kinto-client',
       version='2.1.0.dev0',


### PR DESCRIPTION
Remove InvalidPlateform Warning on Python < 2.7.9.

See https://urllib3.readthedocs.org/en/latest/security.html#installing-urllib3-with-sni-support-and-certificates