### PR TITLE
Remove PyFxA and requests-hawk from requirements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,7 @@ with codecs.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
     README = f.read()
 
 REQUIREMENTS = [
-    'PyFxA',
     'requests>=2.8.1',
-    'requests-hawk',
     'unidecode',
     'six'
 ]


### PR DESCRIPTION
They are actually not used in the current codebase, and trigger a lot of
dependencies that aren't useful in a lot of different cases.

Fixes #35

r? @leplatrem