### PR TITLE
Change update collection signature

### DIFF
--- a/kinto_client/__init__.py
+++ b/kinto_client/__init__.py
@@ -249,8 +249,8 @@ class Client(object):
                                        headers=headers)
         return resp
 
-    def update_collection(self, collection=None, bucket=None,
-                          data=None, permissions=None, method='put',
+    def update_collection(self, data=None, collection=None, bucket=None,
+                          permissions=None, method='put',
                           safe=True, last_modified=None):
         endpoint = self._get_endpoint('collection', bucket, collection)
         headers = self._get_cache_headers(safe, data, last_modified)

--- a/kinto_client/tests/test_client.py
+++ b/kinto_client/tests/test_client.py
@@ -207,8 +207,8 @@ class CollectionTest(unittest.TestCase):
 
     def test_collection_update_issues_an_http_put(self):
         self.client.update_collection(
-            'mycollection',
-            data={'foo': 'bar'},
+            {'foo': 'bar'},
+            collection='mycollection',
             permissions=mock.sentinel.permissions)
 
         url = '/buckets/mybucket/collections/mycollection'
@@ -218,8 +218,8 @@ class CollectionTest(unittest.TestCase):
 
     def test_update_handles_last_modified(self):
         self.client.update_collection(
-            'mycollection',
-            data={'foo': 'bar'},
+            {'foo': 'bar'},
+            collection='mycollection',
             last_modified=1234)
 
         url = '/buckets/mybucket/collections/mycollection'
@@ -231,8 +231,8 @@ class CollectionTest(unittest.TestCase):
     def test_collection_update_use_an_if_match_header(self):
         data = {'foo': 'bar', 'last_modified': '1234'}
         self.client.update_collection(
-            'mycollection',
-            data=data,
+            data,
+            collection='mycollection',
             permissions=mock.sentinel.permissions)
 
         url = '/buckets/mybucket/collections/mycollection'


### PR DESCRIPTION
Before, the collection was passed as the first argument, and some clients where
passing the data as the first argument, as it seems to be the easier thing to
do.

Fixes #40

r? @leplatrem