### PR TITLE
Add missing methods (fixes #55)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,12 @@ If no specific bucket name is provided, the "default" bucket is used.
     # It is also possible to manipulate bucket permissions (see later)
     client.update_bucket('payments', permissions={})
 
+    # Or delete a bucket and everything under.
+    client.delete_bucket('payment')
+
+    # Or even every writable buckets.
+    client.delete_buckets()
+
 
 Collections
 -----------
@@ -118,6 +124,8 @@ A collection is where records are stored.
     # To delete an existing collection.
     client.delete_collection('receipts', bucket='payments')
 
+    # Or every collections in a bucket.
+    client.delete_collections(bucket='payments')
 
 Records
 -------
@@ -145,9 +153,12 @@ A record is a dict with the "permissions" and "data" keys.
     # Update multiple records at once.
     client.update_records(records, collection='todos')
 
-    # It is also possible to delete records.
+    # It is also possible to delete a record.
     client.delete_record(id='89881454-e4e9-4ef0-99a9-404d95900352',
                          collection='todos')
+
+    # Or every records of a collection.
+    client.delete_records(collection='todos')
 
 Permissions
 -----------

--- a/kinto_client/__init__.py
+++ b/kinto_client/__init__.py
@@ -159,20 +159,27 @@ class Client(object):
                                               safe=safe)
         headers = DO_NOT_OVERWRITE if safe else None
         endpoint = self._get_endpoint('bucket', bucket)
-        resp, _ = self.session.request('put', endpoint,
+        resp, _ = self.session.request('put', endpoint, data=data,
                                        permissions=permissions,
                                        headers=headers)
         return resp
 
     def update_bucket(self, bucket=None, data=None, permissions=None,
-                      safe=True, last_modified=None):
+                      safe=True, last_modified=None, method='put'):
         endpoint = self._get_endpoint('bucket', bucket)
         headers = self._get_cache_headers(safe, data, last_modified)
-        resp, _ = self.session.request('patch', endpoint, data=data,
+        resp, _ = self.session.request(method, endpoint, data=data,
                                        permissions=permissions,
                                        headers=headers)
-
         return resp
+
+    def patch_bucket(self, *args, **kwargs):
+        kwargs['method'] = 'patch'
+        return self.update_bucket(*args, **kwargs)
+
+    def get_buckets(self):
+        endpoint = self._get_endpoint('buckets')
+        return self._paginated(endpoint)
 
     def get_bucket(self, bucket=None):
         endpoint = self._get_endpoint('bucket', bucket)
@@ -184,6 +191,12 @@ class Client(object):
 
     def delete_bucket(self, bucket=None, safe=True, last_modified=None):
         endpoint = self._get_endpoint('bucket', bucket)
+        headers = self._get_cache_headers(safe, last_modified=last_modified)
+        resp, _ = self.session.request('delete', endpoint, headers=headers)
+        return resp['data']
+
+    def delete_buckets(self, safe=True, last_modified=None):
+        endpoint = self._get_endpoint('buckets')
         headers = self._get_cache_headers(safe, last_modified=last_modified)
         resp, _ = self.session.request('delete', endpoint, headers=headers)
         return resp['data']
@@ -233,6 +246,12 @@ class Client(object):
     def delete_collection(self, collection=None, bucket=None,
                           safe=True, last_modified=None):
         endpoint = self._get_endpoint('collection', bucket, collection)
+        headers = self._get_cache_headers(safe, last_modified=last_modified)
+        resp, _ = self.session.request('delete', endpoint, headers=headers)
+        return resp['data']
+
+    def delete_collections(self, bucket=None, safe=True, last_modified=None):
+        endpoint = self._get_endpoint('collections', bucket)
         headers = self._get_cache_headers(safe, last_modified=last_modified)
         resp, _ = self.session.request('delete', endpoint, headers=headers)
         return resp['data']
@@ -290,14 +309,16 @@ class Client(object):
     def delete_record(self, id, collection=None, bucket=None,
                       safe=True, last_modified=None):
         endpoint = self._get_endpoint('record', bucket, collection, id)
-        resp, _ = self.session.request(
-            'delete', endpoint,
-            headers=self._get_cache_headers(safe, last_modified=last_modified))
+        headers = self._get_cache_headers(safe, last_modified=last_modified)
+        resp, _ = self.session.request('delete', endpoint, headers=headers)
         return resp['data']
 
-    def delete_records(self, records):
-        # XXX To be done with a BATCH operation
-        pass
+    def delete_records(self, collection=None, bucket=None,
+                       safe=True, last_modified=None):
+        endpoint = self._get_endpoint('records', bucket, collection)
+        headers = self._get_cache_headers(safe, last_modified=last_modified)
+        resp, _ = self.session.request('delete', endpoint, headers=headers)
+        return resp['data']
 
     def __repr__(self):
         endpoint = self._get_endpoint(

--- a/kinto_client/tests/config/kinto.ini
+++ b/kinto_client/tests/config/kinto.ini
@@ -1,15 +1,8 @@
 [app:main]
 use = egg:kinto
 
-pyramid.debug_notfound = true
-
-cliquet.http_scheme = http
-cliquet.http_host = localhost:8888
-
-cliquet.userid_hmac_secret = b4c96a8d91846eb4692291d88fe5a97d
-multiauth.policies = basicauth
+kinto.userid_hmac_secret = b4c96a8d91846eb4692291d88fe5a97d
 kinto.flush_endpoint_enabled = true
-
 kinto.paginate_by = 5
 
 [server:main]


### PR DESCRIPTION
* [x] Add missing methods in client
* [x] Add explicit patch for bucket for consistency
* [x] Add functional tests
* [x] Add missing `DELETE` endpoints for `/buckets` and `/buckets/<>/collections` on Kinto server wait for https://github.com/Kinto/kinto/pull/428 to be merged.