### PR TITLE
Make argparse `collection` and `bucket` options optional.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,15 @@ This document describes changes between each past release.
 3.2.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+**Breaking changes**
+
+- The ``cli_utils.set_parser_server_options()`` was renamed
+  ``cli_utils.add_parser_options()`` (#63)
+
+**New features**
+
+- The ``cli_utils`` can now handle option bucket and collection
+  parameters. (#63)
 
 
 3.1.0 (2016-02-16)

--- a/kinto_client/cli_utils.py
+++ b/kinto_client/cli_utils.py
@@ -32,14 +32,14 @@ class AuthAction(argparse.Action):
             setattr(namespace, self.dest, get_auth(values))
 
 
-def set_parser_server_options(parser=None,
-                              default_server=None,
-                              default_auth=None,
-                              default_bucket=None,
-                              default_collection=None,
-                              with_bucket=True,
-                              with_collection=True,
-                              **kwargs):
+def add_parser_options(parser=None,
+                       default_server=None,
+                       default_auth=None,
+                       default_bucket=None,
+                       default_collection=None,
+                       include_bucket=True,
+                       include_collection=True,
+                       **kwargs):
 
     if parser is None:
         parser = argparse.ArgumentParser(**kwargs)
@@ -52,12 +52,12 @@ def set_parser_server_options(parser=None,
                         help='BasicAuth token:my-secret',
                         type=str, default=default_auth, action=AuthAction)
 
-    if with_bucket:
+    if include_bucket:
         parser.add_argument('-b', '--bucket',
                             help='Bucket name.',
                             type=str, default=default_bucket)
 
-    if with_collection:
+    if include_collection:
         parser.add_argument('-c', '--collection',
                             help='Collection name.',
                             type=str, default=default_collection)

--- a/kinto_client/cli_utils.py
+++ b/kinto_client/cli_utils.py
@@ -37,6 +37,8 @@ def set_parser_server_options(parser=None,
                               default_auth=None,
                               default_bucket=None,
                               default_collection=None,
+                              bucket=True,
+                              collection=True,
                               **kwargs):
 
     if parser is None:
@@ -50,13 +52,15 @@ def set_parser_server_options(parser=None,
                         help='BasicAuth token:my-secret',
                         type=str, default=default_auth, action=AuthAction)
 
-    parser.add_argument('-b', '--bucket',
-                        help='Bucket name.',
-                        type=str, default=default_bucket)
+    if bucket:
+        parser.add_argument('-b', '--bucket',
+                            help='Bucket name.',
+                            type=str, default=default_bucket)
 
-    parser.add_argument('-c', '--collection',
-                        help='Collection name.',
-                        type=str, default=default_collection)
+    if collection:
+        parser.add_argument('-c', '--collection',
+                            help='Collection name.',
+                            type=str, default=default_collection)
 
     # Defaults
     parser.add_argument('-v', '--verbose', action='store_const',

--- a/kinto_client/cli_utils.py
+++ b/kinto_client/cli_utils.py
@@ -21,8 +21,8 @@ def create_client_from_args(args):
     """Return a client from parser args."""
     return Client(server_url=args.server,
                   auth=args.auth,
-                  bucket=args.bucket,
-                  collection=args.collection)
+                  bucket=getattr(args, 'bucket', None),
+                  collection=getattr(args, 'collection', None))
 
 
 class AuthAction(argparse.Action):
@@ -37,8 +37,8 @@ def set_parser_server_options(parser=None,
                               default_auth=None,
                               default_bucket=None,
                               default_collection=None,
-                              bucket=True,
-                              collection=True,
+                              with_bucket=True,
+                              with_collection=True,
                               **kwargs):
 
     if parser is None:
@@ -52,12 +52,12 @@ def set_parser_server_options(parser=None,
                         help='BasicAuth token:my-secret',
                         type=str, default=default_auth, action=AuthAction)
 
-    if bucket:
+    if with_bucket:
         parser.add_argument('-b', '--bucket',
                             help='Bucket name.',
                             type=str, default=default_bucket)
 
-    if collection:
+    if with_collection:
         parser.add_argument('-c', '--collection',
                             help='Collection name.',
                             type=str, default=default_collection)

--- a/kinto_client/tests/test_cli_utils.py
+++ b/kinto_client/tests/test_cli_utils.py
@@ -40,7 +40,7 @@ class ParserServerOptionsTest(unittest.TestCase):
 
     def test_set_parser_server_options_can_ignore_bucket_and_collection(self):
         parser = cli_utils.set_parser_server_options(
-            bucket=None, collection=None)
+            with_bucket=None, with_collection=None)
         parameters = [
             ['-h', '--help'],
             ['-s', '--server'],
@@ -95,7 +95,8 @@ class GetAuthTest(unittest.TestCase):
 
 class ClientFromArgsTest(unittest.TestCase):
 
-    def setUp(self):
+    @mock.patch('kinto_client.cli_utils.Client')
+    def test_create_client_from_args_build_a_client(self, mocked_client):
         parser = cli_utils.set_parser_server_options(
             default_server="https://firefox.settings.services.mozilla.com/",
             default_bucket="blocklists",
@@ -103,13 +104,29 @@ class ClientFromArgsTest(unittest.TestCase):
             default_auth=('user', 'password')
         )
 
-        self.args = parser.parse_args([])
+        args = parser.parse_args([])
 
-    @mock.patch('kinto_client.cli_utils.Client')
-    def test_create_client_from_args_build_a_client(self, mocked_client):
-        cli_utils.create_client_from_args(self.args)
+        cli_utils.create_client_from_args(args)
         mocked_client.assert_called_with(
             server_url='https://firefox.settings.services.mozilla.com/',
             auth=('user', 'password'),
             bucket='blocklists',
             collection='certificates')
+
+    @mock.patch('kinto_client.cli_utils.Client')
+    def test_create_client_from_args_default_bucket_and_collection_to_none(
+            self, mocked_client):
+        parser = cli_utils.set_parser_server_options(
+            default_server="https://firefox.settings.services.mozilla.com/",
+            default_auth=('user', 'password'),
+            with_bucket=False, with_collection=False
+        )
+
+        args = parser.parse_args([])
+
+        cli_utils.create_client_from_args(args)
+        mocked_client.assert_called_with(
+            server_url='https://firefox.settings.services.mozilla.com/',
+            auth=('user', 'password'),
+            bucket=None,
+            collection=None)

--- a/kinto_client/tests/test_cli_utils.py
+++ b/kinto_client/tests/test_cli_utils.py
@@ -40,7 +40,7 @@ class ParserServerOptionsTest(unittest.TestCase):
 
     def test_set_parser_server_options_can_ignore_bucket_and_collection(self):
         parser = cli_utils.set_parser_server_options(
-            with_bucket=None, with_collection=None)
+            with_bucket=False, with_collection=False)
         parameters = [
             ['-h', '--help'],
             ['-s', '--server'],

--- a/kinto_client/tests/test_cli_utils.py
+++ b/kinto_client/tests/test_cli_utils.py
@@ -38,6 +38,20 @@ class ParserServerOptionsTest(unittest.TestCase):
                                    *ALL_PARAMETERS)
         assert len(parser._actions) == 9
 
+    def test_set_parser_server_options_can_ignore_bucket_and_collection(self):
+        parser = cli_utils.set_parser_server_options(
+            bucket=None, collection=None)
+        parameters = [
+            ['-h', '--help'],
+            ['-s', '--server'],
+            ['-a', '--auth'],
+            ['-v', '--verbose'],
+            ['-q', '--quiet'],
+            ['-D', '--debug'],
+        ]
+        self.assert_option_strings(parser, *parameters)
+        assert len(parser._actions) == 6
+
     def test_can_change_default_values(self):
         parser = cli_utils.set_parser_server_options(
             default_server="https://firefox.settings.services.mozilla.com/",

--- a/kinto_client/tests/test_cli_utils.py
+++ b/kinto_client/tests/test_cli_utils.py
@@ -23,24 +23,24 @@ class ParserServerOptionsTest(unittest.TestCase):
                         for action in parser._actions]), \
                 "%s not found" % option_strings
 
-    def test_set_parser_server_options_create_a_parser_if_needed(self):
-        parser = cli_utils.set_parser_server_options()
+    def test_add_parser_options_create_a_parser_if_needed(self):
+        parser = cli_utils.add_parser_options()
         self.assert_option_strings(parser, *ALL_PARAMETERS)
         assert len(parser._actions) == 8
 
-    def test_set_parser_server_options_adds_arguments_on_existing_parser(self):
+    def test_add_parser_options_adds_arguments_on_existing_parser(self):
         parser = argparse.ArgumentParser(prog="importer")
         parser.add_argument('-t', '--type', help='File type',
                             type=str, default='xml')
 
-        parser = cli_utils.set_parser_server_options(parser)
+        parser = cli_utils.add_parser_options(parser)
         self.assert_option_strings(parser, ['-t', '--type'],
                                    *ALL_PARAMETERS)
         assert len(parser._actions) == 9
 
-    def test_set_parser_server_options_can_ignore_bucket_and_collection(self):
-        parser = cli_utils.set_parser_server_options(
-            with_bucket=False, with_collection=False)
+    def test_add_parser_options_can_ignore_bucket_and_collection(self):
+        parser = cli_utils.add_parser_options(
+            include_bucket=False, include_collection=False)
         parameters = [
             ['-h', '--help'],
             ['-s', '--server'],
@@ -53,7 +53,7 @@ class ParserServerOptionsTest(unittest.TestCase):
         assert len(parser._actions) == 6
 
     def test_can_change_default_values(self):
-        parser = cli_utils.set_parser_server_options(
+        parser = cli_utils.add_parser_options(
             default_server="https://firefox.settings.services.mozilla.com/",
             default_bucket="blocklists",
             default_collection="certificates",
@@ -85,7 +85,7 @@ class GetAuthTest(unittest.TestCase):
         assert password == "password"
 
     def test_get_auth_is_called_by_argparse(self):
-        parser = cli_utils.set_parser_server_options(
+        parser = cli_utils.add_parser_options(
             default_server="https://firefox.settings.services.mozilla.com/",
             default_bucket="blocklists",
             default_collection="certificates")
@@ -97,7 +97,7 @@ class ClientFromArgsTest(unittest.TestCase):
 
     @mock.patch('kinto_client.cli_utils.Client')
     def test_create_client_from_args_build_a_client(self, mocked_client):
-        parser = cli_utils.set_parser_server_options(
+        parser = cli_utils.add_parser_options(
             default_server="https://firefox.settings.services.mozilla.com/",
             default_bucket="blocklists",
             default_collection="certificates",
@@ -116,10 +116,10 @@ class ClientFromArgsTest(unittest.TestCase):
     @mock.patch('kinto_client.cli_utils.Client')
     def test_create_client_from_args_default_bucket_and_collection_to_none(
             self, mocked_client):
-        parser = cli_utils.set_parser_server_options(
+        parser = cli_utils.add_parser_options(
             default_server="https://firefox.settings.services.mozilla.com/",
             default_auth=('user', 'password'),
-            with_bucket=False, with_collection=False
+            include_bucket=False, include_collection=False
         )
 
         args = parser.parse_args([])


### PR DESCRIPTION
For xml2kinto and kinto2xml we need to define multiple bucket/collection couples.