### PR TITLE
_get_endpoint should be part of the public.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -267,6 +267,25 @@ It is possible (but not recommended) to force this value in the clients:
                   retry=10,
                   retry_after=5)
 
+
+Generating endpoint paths
+-------------------------
+
+You may want to generate some endpoint paths, you can use the
+get_endpoint utility to do so:
+
+.. code-block:: python
+
+    client = Client(server_url='http://localhost:8888/v1',
+                    auth=('token', 'your-token'),
+                    bucket="payments",
+                    collection="receipts")
+    print(client.get_endpoint("record",
+                              id="c6894b2c-1856-11e6-9415-3c970ede22b0"))
+
+    # '/buckets/payments/collections/receipts/records/c6894b2c-1856-11e6-9415-3c970ede22b0'
+
+
 Command-line scripts
 --------------------
 

--- a/kinto_client/__init__.py
+++ b/kinto_client/__init__.py
@@ -93,7 +93,7 @@ class Client(object):
     def get_endpoint(self, name, bucket=None, collection=None, id=None):
         """Return the endpoint with named parameters.
 
-           Please always use the method as if it was defined like that:
+           Please always use the method as if it was defined like this:
 
                get_endpoint(self, name, *,
                             bucket=None, collection=None, id=None)

--- a/kinto_client/__init__.py
+++ b/kinto_client/__init__.py
@@ -162,7 +162,7 @@ class Client(object):
     # Server Info
 
     def server_info(self):
-        endpoint = self._get_endpoint('root')
+        endpoint = self.get_endpoint('root')
         resp, _ = self.session.request('get', endpoint)
         return resp
 


### PR DESCRIPTION
Working with Kinto.py and Kinto-Attachment in order for the upload scripts we ended up using client._get_endpoint('record', record_id)

- [x] Rename ``_get_endpoint`` to ``get_endpoint``
- [x] Use named parameters.